### PR TITLE
Improve unique naming throughout

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  * Author URI:   https://happyprime.co
  * License:      GPLv2 or later
  * License URI:  https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Text Domain:  soft-hyphenate
+ * Text Domain:  hp-soft-hyphenate
  * Requires PHP: 7.4
  *
  * This program is free software; you can redistribute it and/or modify
@@ -21,10 +21,33 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @package soft-hyphenate
+ * @package HappyPrime\SoftHyphenate
  */
 
 namespace HappyPrime\SoftHyphenate;
+
+/**
+ * A common prefix used with settings pages, fields, sections, and other
+ * components to help with uniquity.
+ *
+ * @var string
+ */
+const PREFIX = 'hp-sh-';
+
+/**
+ * A common slug combined with the prefix and used to build the names of
+ * settings pages, fields, sections, and other components.
+ *
+ * @var string
+ */
+const SLUG = 'soft-hyphenate';
+
+/**
+ * The main option key used for the plugin.
+ *
+ * @var string
+ */
+const OPTION_NAME = 'hp_soft_hyphenate';
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  * Author URI:   https://happyprime.co
  * License:      GPLv2 or later
  * License URI:  https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Text Domain:  hp-soft-hyphenate
+ * Text Domain:  soft-hyphenate
  * Requires PHP: 7.4
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -40,8 +40,8 @@ class Admin {
 	 */
 	public static function add_settings_page(): void {
 		add_options_page(
-			__( 'Soft Hyphenate', 'hp-soft-hyphenate' ),
-			__( 'Soft Hyphenate', 'hp-soft-hyphenate' ),
+			__( 'Soft Hyphenate', 'soft-hyphenate' ),
+			__( 'Soft Hyphenate', 'soft-hyphenate' ),
 			'manage_options',
 			self::SETTINGS_PAGE,
 			[ __CLASS__, 'display_settings_page' ]
@@ -63,14 +63,14 @@ class Admin {
 
 		add_settings_section(
 			self::SETTINGS_SECTION,
-			__( 'Hyphenation Suggestions', 'hp-soft-hyphenate' ),
+			__( 'Hyphenation Suggestions', 'soft-hyphenate' ),
 			[ __CLASS__, 'section_callback' ],
 			self::SETTINGS_PAGE
 		);
 
 		add_settings_field(
 			self::SETTINGS_SECTION . '-input',
-			__( 'Suggestions', 'hp-soft-hyphenate' ),
+			__( 'Suggestions', 'soft-hyphenate' ),
 			[ __CLASS__, 'display_hyphenation_suggestion_field' ],
 			self::SETTINGS_PAGE,
 			self::SETTINGS_SECTION
@@ -83,7 +83,7 @@ class Admin {
 	public static function display_settings_page(): void {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Soft Hyphenate Settings', 'hp-soft-hyphenate' ); ?></h1>
+			<h1><?php esc_html_e( 'Soft Hyphenate Settings', 'soft-hyphenate' ); ?></h1>
 			<form action="options.php" method="post">
 			<?php
 				settings_fields( self::OPTION_GROUP );
@@ -101,7 +101,7 @@ class Admin {
 	public static function section_callback(): void {
 		printf(
 			'<p>%s</p>',
-			esc_html__( 'Enter your hyphenation suggestions (e.g. "hyph-en-ate") below, one word per line.', 'hp-soft-hyphenate' )
+			esc_html__( 'Enter your hyphenation suggestions (e.g. "hyph-en-ate") below, one word per line.', 'soft-hyphenate' )
 		);
 	}
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -2,7 +2,7 @@
 /**
  * Manage admin settings for the plugin.
  *
- * @package soft-hyphenate
+ * @package HappyPrime\SoftHyphenate
  */
 
 namespace HappyPrime\SoftHyphenate;
@@ -12,11 +12,15 @@ namespace HappyPrime\SoftHyphenate;
  */
 class Admin {
 
-	const OPTION_PREFIX = 'hp-soft-';
-	const MENU_SLUG     = 'soft-hyphenate';
-	const PAGE_SLUG     = 'soft-hyphenate';
-	const SECTION_ID    = 'hyphenation-suggestion-section';
-	const OPTION_GROUP  = 'soft-hyphenate';
+	/**
+	 * The unique identifier for the settings page.
+	 */
+	const SETTINGS_PAGE = PREFIX . SLUG . '-page';
+
+	/**
+	 * The unique identifier for the option group.
+	 */
+	const OPTION_GROUP = PREFIX . SLUG . '-option-group';
 
 	/**
 	 * Initialize customizations in the WordPress admin.
@@ -31,10 +35,10 @@ class Admin {
 	 */
 	public static function add_settings_page(): void {
 		add_options_page(
-			__( 'Soft Hyphenate', 'soft-hyphenate' ),
-			__( 'Soft Hyphenate', 'soft-hyphenate' ),
+			__( 'Soft Hyphenate', 'hp-soft-hyphenate' ),
+			__( 'Soft Hyphenate', 'hp-soft-hyphenate' ),
 			'manage_options',
-			self::MENU_SLUG,
+			self::SETTINGS_PAGE,
 			[ __CLASS__, 'display_settings_page' ]
 		);
 	}
@@ -45,7 +49,7 @@ class Admin {
 	public static function settings_init(): void {
 		register_setting(
 			self::OPTION_GROUP,
-			self::OPTION_PREFIX . 'hyphenate',
+			OPTION_NAME,
 			[
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_textarea_field',
@@ -53,18 +57,18 @@ class Admin {
 		);
 
 		add_settings_section(
-			self::SECTION_ID,
-			__( 'Hyphenation Suggestions', 'soft-hyphenate' ),
+			'hyphenation-suggestions',
+			__( 'Hyphenation Suggestions', 'hp-soft-hyphenate' ),
 			[ __CLASS__, 'section_callback' ],
-			self::PAGE_SLUG
+			self::SETTINGS_PAGE
 		);
 
 		add_settings_field(
-			'hyphenation-suggestions',
+			'hyphenation-suggestions-input',
 			'',
 			[ __CLASS__, 'display_hyphenation_suggestion_field' ],
-			'soft-hyphenate',
-			'hyphenation-suggestion-section'
+			self::SETTINGS_PAGE,
+			'hyphenation-suggestions'
 		);
 	}
 
@@ -74,13 +78,11 @@ class Admin {
 	public static function display_settings_page(): void {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Soft Hyphenate Settings', 'soft-hyphenate' ); ?></h1>
+			<h1><?php esc_html_e( 'Soft Hyphenate Settings', 'hp-soft-hyphenate' ); ?></h1>
 			<form action="options.php" method="post">
 			<?php
 				settings_fields( self::OPTION_GROUP );
-
-				do_settings_sections( self::PAGE_SLUG );
-
+				do_settings_sections( self::SETTINGS_PAGE );
 				submit_button();
 			?>
 			</form>
@@ -94,7 +96,7 @@ class Admin {
 	public static function section_callback(): void {
 		printf(
 			'<p>%s</p>',
-			esc_html__( 'Enter your hyphenation suggestions (e.g. "hyph-en-ate") below, one word per line.', 'soft-hyphenate' )
+			esc_html__( 'Enter your hyphenation suggestions (e.g. "hyph-en-ate") below, one word per line.', 'hp-soft-hyphenate' )
 		);
 	}
 
@@ -102,14 +104,16 @@ class Admin {
 	 * Render the field.
 	 */
 	public static function display_hyphenation_suggestion_field(): void {
-		$hyphenation_suggestion = get_option( self::OPTION_PREFIX . 'hyphenate', '' );
+		$hyphenation_suggestion = get_option( OPTION_NAME, '' );
 
 		if ( ! is_scalar( $hyphenation_suggestion ) ) {
 			$hyphenation_suggestion = '';
 		}
 
 		printf(
-			'<textarea name="hp-soft-hyphenate" id="hp-soft-hyphenate" rows="20" cols="50">%s</textarea>',
+			'<textarea name="%s" id="%s" rows="20" cols="50">%s</textarea>',
+			esc_attr( OPTION_NAME ),
+			esc_attr( OPTION_NAME ),
 			esc_textarea( (string) $hyphenation_suggestion )
 		);
 	}

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -23,6 +23,11 @@ class Admin {
 	const OPTION_GROUP = PREFIX . SLUG . '-option-group';
 
 	/**
+	 * The unique identifier for our main settings section.
+	 */
+	const SETTINGS_SECTION = 'hyphenation-suggestions';
+
+	/**
 	 * Initialize customizations in the WordPress admin.
 	 */
 	public static function init(): void {
@@ -57,18 +62,18 @@ class Admin {
 		);
 
 		add_settings_section(
-			'hyphenation-suggestions',
+			self::SETTINGS_SECTION,
 			__( 'Hyphenation Suggestions', 'hp-soft-hyphenate' ),
 			[ __CLASS__, 'section_callback' ],
 			self::SETTINGS_PAGE
 		);
 
 		add_settings_field(
-			'hyphenation-suggestions-input',
-			'',
+			self::SETTINGS_SECTION . '-input',
+			__( 'Suggestions', 'hp-soft-hyphenate' ),
 			[ __CLASS__, 'display_hyphenation_suggestion_field' ],
 			self::SETTINGS_PAGE,
-			'hyphenation-suggestions'
+			self::SETTINGS_SECTION
 		);
 	}
 

--- a/src/Hyphenate.php
+++ b/src/Hyphenate.php
@@ -2,7 +2,7 @@
 /**
  * Manage hyphenation of content.
  *
- * @package soft-hyphenate
+ * @package HappyPrime\SoftHyphenate
  */
 
 namespace HappyPrime\SoftHyphenate;
@@ -36,7 +36,7 @@ class Hyphenate {
 	 * Load the suggestions from the database.
 	 */
 	public function load_suggestions(): void {
-		$suggestions = get_option( Admin::OPTION_PREFIX . 'hyphenate' );
+		$suggestions = get_option( OPTION_NAME );
 
 		if ( ! is_scalar( $suggestions ) || empty( $suggestions ) ) {
 			return;

--- a/src/Init.php
+++ b/src/Init.php
@@ -2,7 +2,7 @@
 /**
  * Initialize the plugin.
  *
- * @package soft-hyphenate
+ * @package HappyPrime\SoftHyphenate
  */
 
 namespace HappyPrime\SoftHyphenate;
@@ -30,7 +30,7 @@ class Init {
 	}
 
 	/**
-	 * Add soft hypens to content.
+	 * Add soft hyphens to content.
 	 *
 	 * @param string $content Content to be soft-hyphenated.
 	 *

--- a/tests/test-hyphenation.php
+++ b/tests/test-hyphenation.php
@@ -8,6 +8,7 @@
  */
 
 use HappyPrime\SoftHyphenate\Hyphenate;
+use HappyPrime\SoftHyphenate;
 
 /**
  * Test the hyphenation of text.
@@ -31,7 +32,7 @@ class TestHyphenation extends WP_UnitTestCase {
 			]
 		);
 
-		update_option( 'hp-soft-hyphenate', $suggestions );
+		update_option( SoftHyphenate\OPTION_NAME, $suggestions );
 	}
 
 	/**
@@ -40,7 +41,7 @@ class TestHyphenation extends WP_UnitTestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
-		delete_option( 'hp-soft-hyphenate' );
+		delete_option( SoftHyphenate\OPTION_NAME );
 	}
 
 	/**


### PR DESCRIPTION
This builds on the work from #15 to help uniquify some of the IDs and slugs used to track data through WordPress

1. Change the `@package` to `HappyPrime\SoftHyphenate`
2. Move the option name constant to `plugin.php` for reuse without requiring `Admin`
3. Move the common prefix and slug constants to `plugin.php` to help clarify how they can be used if ever needed in the future.
4. Clarify the naming and content of the option group and settings page constants as part of the `Admin` class.

Fixes #14 